### PR TITLE
Add new functions that exclude blessed references

### DIFF
--- a/Util.xs
+++ b/Util.xs
@@ -79,6 +79,12 @@ DECL(is_formatref, ==, 1, SVt_PVFM)
 DECL(is_ioref,     ==, 1, SVt_PVIO)
 DECL(is_refref,    ==, 1, SVt_LAST+1) /* cannot match a real svtype value */
 
+DECL(is_plain_scalarref, <,  !sv_isobject(ref), SVt_PVAV)
+DECL(is_plain_arrayref,  ==, !sv_isobject(ref), SVt_PVAV)
+DECL(is_plain_hashref,   ==, !sv_isobject(ref), SVt_PVHV)
+DECL(is_plain_coderef,   ==, !sv_isobject(ref), SVt_PVCV)
+DECL(is_plain_globref,   ==, !sv_isobject(ref), SVt_PVGV)
+
 /* start is_ref */
 
 /* this is the equivalent of DECL_RUNTIME_FUNC */
@@ -137,6 +143,11 @@ BOOT:
         SET_OP( is_formatref, "FORMAT" )
         SET_OP( is_ioref,     "IO"     )
         SET_OP( is_refref,    "REF"    )
+        SET_OP( is_plain_scalarref, "plain SCALAR" )
+        SET_OP( is_plain_arrayref,  "plain ARRAY"  )
+        SET_OP( is_plain_hashref,   "plain HASH"   )
+        SET_OP( is_plain_coderef,   "plain CODE"   )
+        SET_OP( is_plain_globref,   "plain GLOB"   )
     }
 
 #else /* not USE_CUSTOM_OPS */
@@ -239,5 +250,30 @@ is_refref(SV *ref)
            If you find this awkward, Please teach me a better way. :)
         */
         XSUB_BODY( ref, ==, 1, SVt_LAST+1 );
+
+SV *
+is_plain_scalarref(SV *ref)
+    PPCODE:
+        XSUB_BODY( ref, <, !sv_isobject(ref), SVt_PVAV );
+
+SV *
+is_plain_arrayref(SV *ref)
+    PPCODE:
+        XSUB_BODY( ref, ==, !sv_isobject(ref), SVt_PVAV );
+
+SV *
+is_plain_hashref(SV *ref)
+    PPCODE:
+        XSUB_BODY( ref, ==, !sv_isobject(ref), SVt_PVHV );
+
+SV *
+is_plain_coderef(SV *ref)
+    PPCODE:
+        XSUB_BODY( ref, ==, !sv_isobject(ref), SVt_PVCV );
+
+SV *
+is_plain_globref(SV *ref)
+    PPCODE:
+        XSUB_BODY( ref, ==, !sv_isobject(ref), SVt_PVGV );
 
 #endif /* not USE_CUSTOM_OPS */

--- a/Util.xs
+++ b/Util.xs
@@ -77,7 +77,7 @@ DECL(is_regexpref, ==, SVt_REGEXP)
 DECL(is_globref,   ==, SVt_PVGV)
 DECL(is_formatref, ==, SVt_PVFM)
 DECL(is_ioref,     ==, SVt_PVIO)
-DECL(is_refref,    ==, -1)
+DECL(is_refref,    ==, SVt_LAST+1) /* cannot match a real svtype value */
 
 /* start is_ref */
 
@@ -238,6 +238,6 @@ is_refref(SV *ref)
            to reference.
            If you find this awkward, Please teach me a better way. :)
         */
-        XSUB_BODY( ref, ==, -1 );
+        XSUB_BODY( ref, ==, SVt_LAST+1 );
 
 #endif /* not USE_CUSTOM_OPS */

--- a/lib/Ref/Util.pm
+++ b/lib/Ref/Util.pm
@@ -10,6 +10,11 @@ our $VERSION     = '0.008';
 our %EXPORT_TAGS = ( 'all' => [qw<
     is_scalarref is_arrayref is_hashref is_coderef is_regexpref
     is_globref is_formatref is_ioref is_refref is_ref
+    is_plain_scalarref
+    is_plain_arrayref
+    is_plain_hashref
+    is_plain_coderef
+    is_plain_globref
 >] );
 our @EXPORT      = ();
 our @EXPORT_OK   = ( @{ $EXPORT_TAGS{'all'} } );
@@ -110,6 +115,13 @@ so even if it's blessed, you know what type of variable is blessed.
     use Ref::Util 'is_hashref';
     my $foo = bless {}, 'PKG';
     is_hashref($foo); # works
+
+On the other hand, in some situations it might be better to specifically
+exclude blessed references. The rationale for that might be that merely
+because some object happens to be implemented using a hash doesn't mean it's
+necessarily correct to treat it as a hash. For these situations, you can use
+C<is_plain_hashref> and friends, which have the same performance benefits as
+C<is_hashref>.
 
 =item * Ignores overloading
 
@@ -276,6 +288,38 @@ Check for an IO reference.
 Check for a reference to a reference.
 
     is_refref( \[] ); # reference to array reference
+
+=head2 is_plain_scalarref($ref)
+
+Check for an unblessed scalar reference.
+
+    is_plain_scalarref(\"hello");
+    is_plain_scalarref(\30);
+    is_plain_scalarref(\$value);
+
+=head2 is_plain_arrayref($ref)
+
+Check for an unblessed array reference.
+
+    is_plain_arrayref([]);
+
+=head2 is_plain_hashref($ref)
+
+Check for an unblessed hash reference.
+
+    is_plain_hashref({});
+
+=head2 is_plain_coderef($ref)
+
+Check for an unblessed code reference.
+
+    is_plain_coderef( sub {} );
+
+=head2 is_plain_globref($ref)
+
+Check for an unblessed glob reference.
+
+    is_plain_globref( \*STDIN );
 
 =head1 SEE ALSO
 

--- a/t/functions.t
+++ b/t/functions.t
@@ -5,7 +5,7 @@ use Test::More;
 BEGIN {
     # 5.8.0+ gets 1 extra test for FORMAT reference
     # (see comment below)
-    plan tests => 17 +
+    plan tests => 27 +
         ( ( $^V && $^V ge v5.8.0 ) ? 2 : 0 );
 
     use_ok('Ref::Util');
@@ -21,6 +21,11 @@ BEGIN {
         is_formatref
         is_ioref
         is_refref
+        is_plain_scalarref
+        is_plain_arrayref
+        is_plain_hashref
+        is_plain_coderef
+        is_plain_globref
     >);
 }
 
@@ -39,6 +44,18 @@ ok( is_hashref({}), 'is_hashref' );
 ok( is_coderef(sub {1}), 'is_coderef' );
 ok( is_regexpref(qr//), 'is_regexpref' );
 ok( is_globref(\*STDIN), 'is_globref' );
+
+ok( is_plain_scalarref(\1), 'is_plain_scalarref' );
+ok( is_plain_arrayref([]), 'is_plain_arrayref' );
+ok( is_plain_hashref({}), 'is_plain_hashref' );
+ok( is_plain_coderef(sub {1}), 'is_plain_coderef' );
+ok( is_plain_globref(\*STDIN), 'is_plain_globref' );
+
+ok( !is_plain_scalarref(do { bless \(my $x = 1) }), 'is_plain_scalarref (blessed)' );
+ok( !is_plain_arrayref(bless []), 'is_plain_arrayref (blessed)' );
+ok( !is_plain_hashref(bless {}), 'is_plain_hashref (blessed)' );
+ok( !is_plain_coderef(bless sub {1}), 'is_plain_coderef (blessed)' );
+ok( !is_plain_globref(bless \*STDIN), 'is_plain_globref (blessed)' );
 
 if ( $^V && $^V ge v5.8.0 ) {
 format STDOUT =


### PR DESCRIPTION
This pull request adds a small family of functions that exclude blessed references. For example, `is_plain_hashref` is like the existing `is_hashref`, but return false for a blessed hash reference. This may be preferable in some situations.

In addition, the first commit in this sequence quells a warning emitted by clang under the `-Wtautological-constant-out-of-range-compare` option.
