### PR TITLE
Throw exceptions on incorrect argument count

### DIFF
--- a/Util.xs
+++ b/Util.xs
@@ -153,6 +153,8 @@ DECL(is_blessed_refref,    REFREF && !PLAIN)
 
 MODULE = Ref::Util		PACKAGE = Ref::Util
 
+PROTOTYPES: DISABLE
+
 BOOT:
     {
         INSTALL( is_ref, "" )

--- a/Util.xs
+++ b/Util.xs
@@ -97,7 +97,7 @@ refutil_sv_rxok(SV *ref)
 
 #define DECL(x, cond) DECL_RUNTIME_FUNC(x, cond)
 #define INSTALL(x, ref) \
-    newXS("Ref::Util::" #x, THX_xsfunc_ ## x, __FILE__);
+    newXSproto("Ref::Util::" #x, THX_xsfunc_ ## x, __FILE__, "$");
 
 #else
 

--- a/Util.xs
+++ b/Util.xs
@@ -55,17 +55,17 @@ refutil_sv_rxok(SV *ref)
 #endif
 
 #define FUNC_BODY(cond)                                 \
-    dSP;                                                \
     SV *ref = POPs;                                     \
     PUSHs( COND(cond) ? &PL_sv_yes : &PL_sv_no )
 
-#define DECL_RUNTIME_FUNC(x, cond)              \
-    static void                                 \
-    THX_xsfunc_ ## x (pTHX_ CV *cv)             \
-    {                                           \
-        dMARK;                                  \
-        dAX;                                    \
-        FUNC_BODY(cond);                        \
+#define DECL_RUNTIME_FUNC(x, cond)                              \
+    static void                                                 \
+    THX_xsfunc_ ## x (pTHX_ CV *cv)                             \
+    {                                                           \
+        dXSARGS;                                                \
+        if (items != 1)                                         \
+            Perl_croak(aTHX_ "Usage: Ref::Util::" #x "(ref)");  \
+        FUNC_BODY(cond);                                        \
     }
 
 #define DECL_XOP(x) \
@@ -75,6 +75,7 @@ refutil_sv_rxok(SV *ref)
     static inline OP *                          \
     x ## _pp(pTHX)                              \
     {                                           \
+        dSP;                                    \
         FUNC_BODY(cond);                        \
         return NORMAL;                          \
     }

--- a/t/toomany.t
+++ b/t/toomany.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Ref::Util qw<is_arrayref is_hashref>;
+
+my $array_func = \&is_arrayref;
+my $hash_func = \&is_hashref;
+
+# We have to use string eval for this, because when the custom op is being
+# used, we expect the direct calls to fail at compile time
+my @cases = (
+    [is_arrayref => 'is_arrayref([], 17)',
+     'direct array call with too many arguments'],
+    [is_arrayref => '$array_func->([], 17)',
+     'array call through coderef with too many arguments'],
+    [is_hashref => 'is_hashref([], 17)',
+     'direct hash call with too many arguments'],
+    [is_hashref => '$hash_func->([], 17)',
+     'hash call through coderef with too many arguments'],
+);
+
+for my $case (@cases) {
+    my ($name, $code, $desc) = @$case;
+    scalar eval $code;
+    my $exn = $@;
+    like($exn, qr/^(?: \QUsage: Ref::Util::$name(ref)\E
+                     | \QToo many arguments for Ref::Util::$name\E\b )/x,
+         $desc);
+}

--- a/t/toomany.t
+++ b/t/toomany.t
@@ -1,10 +1,13 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 6;
 use Ref::Util qw<is_arrayref is_hashref>;
 
 my $array_func = \&is_arrayref;
 my $hash_func = \&is_hashref;
+
+is(prototype($array_func), '$', 'is_arrayref has "$" prototype');
+is(prototype($hash_func), '$', 'is_hashref has "$" prototype');
 
 # We have to use string eval for this, because when the custom op is being
 # used, we expect the direct calls to fail at compile time


### PR DESCRIPTION
This was broken for Perls without custom ops when the XS and op-based implementations were unified. I think it had never worked on Perls with custom ops when calling the XS routines through a code ref.
