### PR TITLE
Handle PERL_OP_PARENT builds

### DIFF
--- a/Util.xs
+++ b/Util.xs
@@ -87,18 +87,18 @@ refutil_sv_rxok(SV *ref)
         return NORMAL;                          \
     }
 
-#define DECL_CALL_CHK_FUNC(x)                                                       \
-    static OP *                                                                     \
-    THX_ck_entersub_args_ ## x(pTHX_ OP *entersubop, GV *namegv, SV *ckobj)         \
-    {                                                                               \
-        entersubop = ck_entersub_args_proto(entersubop, namegv, ckobj);             \
-        OP *argparent = cUNOPx( entersubop )->op_first;                             \
-        OP *arg = OpSIBLING( cLISTOPx(argparent)->op_first );                       \
-        OpLASTSIB_set(arg, argparent);                                              \
-        OP *newop = newUNOP( OP_NULL, 0, arg );                                     \
-        newop->op_type   = OP_CUSTOM;                                               \
-        newop->op_ppaddr = x ## _pp;                                                \
-        return newop;                                                               \
+#define DECL_CALL_CHK_FUNC(x)                                               \
+    static OP *                                                             \
+    THX_ck_entersub_args_ ## x(pTHX_ OP *entersubop, GV *namegv, SV *ckobj) \
+    {                                                                       \
+        entersubop = ck_entersub_args_proto(entersubop, namegv, ckobj);     \
+        OP *argparent = cUNOPx( entersubop )->op_first;                     \
+        OP *arg = OpSIBLING( cLISTOPx(argparent)->op_first );               \
+        OpLASTSIB_set(arg, argparent);                                      \
+        OP *newop = newUNOP( OP_NULL, 0, arg );                             \
+        newop->op_type   = OP_CUSTOM;                                       \
+        newop->op_ppaddr = x ## _pp;                                        \
+        return newop;                                                       \
     }
 
 #if !USE_CUSTOM_OPS


### PR DESCRIPTION
This is the problem that @wolfsage mentioned. Turned out to be easier to fix than I'd expected!
