### PR TITLE
Minor changes for kwalitee

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,5 +24,6 @@ WriteMakefile(
             },
         },
     },
+    MIN_PERL_VERSION => '5.6.2',
 );
 

--- a/lib/Ref/Util.pm
+++ b/lib/Ref/Util.pm
@@ -481,3 +481,8 @@ The following people have been invaluable in their feedback and support.
 =item * Aaron Crane
 
 =back
+
+=head1 LICENSE
+
+This software is made available under the MIT Licence as stated in the
+accompanying LICENSE file.


### PR DESCRIPTION
I've been assigned Ref::Util as this month's [CPAN-PR Challenge](http://cpan-prc.org/) and propose these 2 small changes to address some of the kwalitee issues outlined on [CPANTS](http://cpants.cpanauthors.org/release/XSAWYERX/Ref-Util-0.020)

Note: The addition of MIN_PERL_VERSION increases the required version of ExtUtils::MakeMaker from 6.46 to 6.48. I've not added any code to handle this (there was none to check for 6.46 already that I could find) but can do so if you would prefer.
