### PR TITLE
Add tests that test all permutations:

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ t/toomany.t
 t/magic.t
 t/b-concise.t
 t/magic-readonly.t
+t/all-permutations.t
 tools/bench.pl
 Util.xs
 .travis.yml

--- a/t/all-permutations.t
+++ b/t/all-permutations.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More 'tests' => 3;
 use Ref::Util ':all';
 
-use DDP; use Data::Dumper;
+# FIXME: plain regular expressions, blessed regular expressions
 
 my $plain_formatref = do {
     format FH1 =
@@ -32,6 +32,7 @@ my %all;
         'plain_arrayref'  => [],
         'plain_hashref'   => +{},
         'plain_coderef'   => sub {'plain_code'},
+        #'plain_regexpref' => qr{plain},
         'plain_globref'   => \*::var_for_globref,
         'plain_formatref' => $plain_formatref,
         'plain_refref'    => \\$plain_scalar,
@@ -40,6 +41,7 @@ my %all;
         'blessed_arrayref'  => bless( [], 'ArrayRef' ),
         'blessed_hashref'   => bless( +{}, 'HashRef' ),
         'blessed_coderef'   => bless( sub {'blessed_code'}, 'CodeRef' ),
+        #'blessed_regexp'    => bless( qr{blessed}, 'BlessedRegexp' ),
         'blessed_globref'   => bless( \*::var_for_blessed_globref, 'GlobRef' ),
         'blessed_formatref' => $blessed_formatref,
         'blessed_refref'    => bless( \\$blessed_scalarref, 'RefRef' ),
@@ -56,18 +58,8 @@ my @all_keys     = sort keys %all;
 my @plain_keys   = sort keys %plain;
 my @blessed_keys = sort keys %blessed;
 
-# FIXME: is_any_ref should added here
-subtest 'is_ref' => sub {
-    # FIXME: is_any_ref() does * 2 on next two lines
-    plan 'tests' => scalar(@all_keys)
-                    + 7;
-
-    foreach my $key (@all_keys) {
-        ok( is_ref( $all{$key} ), "is_ref($key) is true" );
-
-        # FIXME: is_any_ref
-        #ok( is_any_ref( $all{$key} ), "is_any_ref($key) is true" );
-    }
+subtest 'non-refs' => sub {
+    plan 'tests' => 7;
 
     foreach my $value ( 0, 1, 'string', '', undef, '0', '0e0' ) {
         # better string representation for test output
@@ -86,7 +78,7 @@ subtest 'plain references' => sub {
     #                  # is_blessed_ref() is not in the %blessed hash
     #                + 1 * scalar(@plain_keys);
 
-    plan 'tests' => 119;
+    plan 'tests' => 168;
 
     # each %plain should fail each test of the %blessed
     foreach my $plain_type (@plain_keys) {
@@ -141,123 +133,204 @@ subtest 'plain references' => sub {
             is_plain_ref($value),
             "is_plain_ref($plain_type) is true",
         );
+
+        ok(
+            is_ref($value),
+            "is_ref($plain_type) is true",
+        );
+
+        #ok(
+        #    is_any_ref($value),
+        #    "is_any_ref($plain_type) is true",
+        #);
     }
 
+    # FIXME: each "is_scalarref" should also be "is_any_scalarref"
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_scalarref'
-            ? ok(
+        if ( $plain_type eq 'plain_scalarref' ) {
+            ok(
                 is_plain_scalarref($value),
                 "is_plain_scalarref($plain_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_scalarref($value),
+                "is_scalarref($plain_type) is true",
+            );
+        } else {
+            ok(
                 !is_plain_scalarref($value),
                 "is_plain_scalarref($plain_type) is false",
             );
-    }
 
-    foreach my $plain_type (@plain_keys) {
-        my $value = $plain{$plain_type};
-
-        $plain_type eq 'plain_scalarref'
-            ? ok(
-                is_plain_scalarref($value),
-                "is_plain_scalarref($plain_type) is true",
-            )
-            : ok(
-                !is_plain_scalarref($value),
-                "is_plain_scalarref($plain_type) is false",
+            ok(
+                !is_scalarref($value),
+                "is_scalarref($plain_type) is false",
             );
+        }
     }
 
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_arrayref'
-            ? ok(
+        if ( $plain_type eq 'plain_arrayref' ) {
+            ok(
                 is_plain_arrayref($value),
                 "is_plain_arrayref($plain_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_arrayref($value),
+                "is_arrayref($plain_type) is true",
+            );
+        } else {
+            ok(
                 !is_plain_arrayref($value),
                 "is_plain_arrayref($plain_type) is false",
             );
+
+            ok(
+                !is_arrayref($value),
+                "is_arrayref($plain_type) is false",
+            );
+        }
     }
 
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_hashref'
-            ? ok(
+        if ( $plain_type eq 'plain_hashref' ) {
+            ok(
                 is_plain_hashref($value),
                 "is_plain_hashref($plain_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_hashref($value),
+                "is_hashref($plain_type) is true",
+            );
+        } else {
+            ok(
                 !is_plain_hashref($value),
                 "is_plain_hashref($plain_type) is false",
             );
+
+            ok(
+                !is_hashref($value),
+                "is_hashref($plain_type) is false",
+            );
+        }
     }
 
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_coderef'
-            ? ok(
+        if ( $plain_type eq 'plain_coderef' ) {
+            ok(
                 is_plain_coderef($value),
                 "is_plain_coderef($plain_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_coderef($value),
+                "is_coderef($plain_type) is true",
+            );
+        } else {
+            ok(
                 !is_plain_coderef($value),
                 "is_plain_coderef($plain_type) is false",
             );
+
+            ok(
+                !is_coderef($value),
+                "is_coderef($plain_type) is false",
+            );
+        }
     }
 
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_globref'
-            ? ok(
+        if ( $plain_type eq 'plain_globref' ) {
+            ok(
                 is_plain_globref($value),
                 "is_plain_globref($plain_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_globref($value),
+                "is_globref($plain_type) is true",
+            );
+        } else {
+            ok(
                 !is_plain_globref($value),
                 "is_plain_globref($plain_type) is false",
             );
+
+            ok(
+                !is_globref($value),
+                "is_globref($plain_type) is false",
+            );
+        }
     }
 
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_formatref'
-            ? ok(
+        if ( $plain_type eq 'plain_formatref' ) {
+            ok(
                 is_plain_formatref($value),
                 "is_plain_formatref($plain_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_formatref($value),
+                "is_formatref($plain_type) is true",
+            );
+        } else {
+            ok(
                 !is_plain_formatref($value),
                 "is_plain_formatref($plain_type) is false",
             );
+
+            ok(
+                !is_formatref($value),
+                "is_formatref($plain_type) is false",
+            );
+        }
     }
 
     foreach my $plain_type (@plain_keys) {
         my $value = $plain{$plain_type};
 
-        $plain_type eq 'plain_globref'
-            ? ok(
-                is_plain_globref($value),
-                "is_plain_globref($plain_type) is true",
-            )
-            : ok(
-                !is_plain_globref($value),
-                "is_plain_globref($plain_type) is false",
+        if ( $plain_type eq 'plain_refref' ) {
+            ok(
+                is_plain_refref($value),
+                "is_plain_refref($plain_type) is true",
             );
+
+            ok(
+                is_refref($value),
+                "is_refref($plain_type) is true",
+            );
+        } else {
+            ok(
+                !is_plain_refref($value),
+                "is_plain_refref($plain_type) is false",
+            );
+
+            ok(
+                !is_refref($value),
+                "is_refref($plain_type) is false",
+            );
+        }
     }
 };
 
 subtest 'blessed references' => sub {
-    plan 'tests' => 119;
+    plan 'tests' => 168;
 
     # each %blessed should fail each test of the %plain
     foreach my $blessed_type (@blessed_keys) {
@@ -312,117 +385,197 @@ subtest 'blessed references' => sub {
             is_blessed_ref($value),
             "is_blessed_ref($blessed_type) is true",
         );
+
+        ok(
+            is_ref($value),
+            "is_ref($blessed_type) is true",
+        );
+
+        #ok(
+        #    is_any_ref($value),
+        #    "is_any_ref($blessed_type) is true",
+        #);
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_scalarref'
-            ? ok(
+        if ( $blessed_type eq 'blessed_scalarref' ) {
+            ok(
                 is_blessed_scalarref($value),
                 "is_blessed_scalarref($blessed_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_scalarref($value),
+                "is_scalarref($blessed_type) is true",
+            );
+        } else {
+            ok(
                 !is_blessed_scalarref($value),
                 "is_blessed_scalarref($blessed_type) is false",
             );
-    }
 
-    foreach my $blessed_type (@blessed_keys) {
-        my $value = $blessed{$blessed_type};
-
-        $blessed_type eq 'blessed_scalarref'
-            ? ok(
-                is_blessed_scalarref($value),
-                "is_blessed_scalarref($blessed_type) is true",
-            )
-            : ok(
-                !is_blessed_scalarref($value),
-                "is_blessed_scalarref($blessed_type) is false",
+            ok(
+                !is_scalarref($value),
+                "is_scalarref($blessed_type) is false",
             );
+        }
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_arrayref'
-            ? ok(
+        if ( $blessed_type eq 'blessed_arrayref' ) {
+            ok(
                 is_blessed_arrayref($value),
                 "is_blessed_arrayref($blessed_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_arrayref($value),
+                "is_arrayref($blessed_type) is true",
+            );
+        } else {
+            ok(
                 !is_blessed_arrayref($value),
                 "is_blessed_arrayref($blessed_type) is false",
             );
+
+            ok(
+                !is_arrayref($value),
+                "is_arrayref($blessed_type) is false",
+            );
+        }
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_hashref'
-            ? ok(
+        if ( $blessed_type eq 'blessed_hashref' ) {
+            ok(
                 is_blessed_hashref($value),
                 "is_blessed_hashref($blessed_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_hashref($value),
+                "is_hashref($blessed_type) is true",
+            );
+        } else {
+            ok(
                 !is_blessed_hashref($value),
                 "is_blessed_hashref($blessed_type) is false",
             );
+
+            ok(
+                !is_hashref($value),
+                "is_hashref($blessed_type) is false",
+            );
+        }
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_coderef'
-            ? ok(
+        if ( $blessed_type eq 'blessed_coderef' ) {
+            ok(
                 is_blessed_coderef($value),
                 "is_blessed_coderef($blessed_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_coderef($value),
+                "is_coderef($blessed_type) is true",
+            );
+        } else {
+            ok(
                 !is_blessed_coderef($value),
                 "is_blessed_coderef($blessed_type) is false",
             );
+
+            ok(
+                !is_coderef($value),
+                "is_coderef($blessed_type) is false",
+            );
+        }
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_globref'
-            ? ok(
+        if ( $blessed_type eq 'blessed_globref' ) {
+            ok(
                 is_blessed_globref($value),
                 "is_blessed_globref($blessed_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_globref($value),
+                "is_globref($blessed_type) is true",
+            );
+        } else {
+            ok(
                 !is_blessed_globref($value),
                 "is_blessed_globref($blessed_type) is false",
             );
+
+            ok(
+                !is_globref($value),
+                "is_globref($blessed_type) is false",
+            );
+        }
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_formatref'
-            ? ok(
+        if ( $blessed_type eq 'blessed_formatref' ) {
+            ok(
                 is_blessed_formatref($value),
                 "is_blessed_formatref($blessed_type) is true",
-            )
-            : ok(
+            );
+
+            ok(
+                is_formatref($value),
+                "is_formatref($blessed_type) is true",
+            );
+        } else {
+            ok(
                 !is_blessed_formatref($value),
                 "is_blessed_formatref($blessed_type) is false",
             );
+
+            ok(
+                !is_formatref($value),
+                "is_formatref($blessed_type) is false",
+            );
+        }
     }
 
     foreach my $blessed_type (@blessed_keys) {
         my $value = $blessed{$blessed_type};
 
-        $blessed_type eq 'blessed_globref'
-            ? ok(
-                is_blessed_globref($value),
-                "is_blessed_globref($blessed_type) is true",
-            )
-            : ok(
-                !is_blessed_globref($value),
-                "is_blessed_globref($blessed_type) is false",
+        if ( $blessed_type eq 'blessed_refref' ) {
+            ok(
+                is_blessed_refref($value),
+                "is_blessed_refref($blessed_type) is true",
             );
+
+            ok(
+                is_refref($value),
+                "is_refref($blessed_type) is true",
+            );
+        } else {
+            ok(
+                !is_blessed_refref($value),
+                "is_blessed_refref($blessed_type) is false",
+            );
+
+            ok(
+                !is_refref($value),
+                "is_refref($blessed_type) is false",
+            );
+        }
     }
 };

--- a/t/all-permutations.t
+++ b/t/all-permutations.t
@@ -1,0 +1,428 @@
+use strict;
+use warnings;
+use Test::More 'tests' => 3;
+use Ref::Util ':all';
+
+use DDP; use Data::Dumper;
+
+my $plain_formatref = do {
+    format FH1 =
+.
+    *FH1{'FORMAT'};
+};
+
+my $blessed_formatref = bless do {
+    format FH2 =
+.
+    *FH2{'FORMAT'};
+}, 'FormatRef';
+
+my ( $var_for_globref, $var_for_blessed_globref );
+my $plain_scalar = 'string';
+my $var_for_scalarref = 'stringy';
+my $blessed_scalarref = bless \$var_for_scalarref, 'ScalarRef';
+
+my %all;
+{;
+    # globref causes this warning
+    no warnings qw<once>;
+
+    %all = (
+        'plain_scalarref' => \$plain_scalar,
+        'plain_arrayref'  => [],
+        'plain_hashref'   => +{},
+        'plain_coderef'   => sub {'plain_code'},
+        'plain_globref'   => \*::var_for_globref,
+        'plain_formatref' => $plain_formatref,
+        'plain_refref'    => \\$plain_scalar,
+
+        'blessed_scalarref' => $blessed_scalarref,
+        'blessed_arrayref'  => bless( [], 'ArrayRef' ),
+        'blessed_hashref'   => bless( +{}, 'HashRef' ),
+        'blessed_coderef'   => bless( sub {'blessed_code'}, 'CodeRef' ),
+        'blessed_globref'   => bless( \*::var_for_blessed_globref, 'GlobRef' ),
+        'blessed_formatref' => $blessed_formatref,
+        'blessed_refref'    => bless( \\$blessed_scalarref, 'RefRef' ),
+    );
+}
+
+my ( %plain, %blessed );
+foreach my $key ( keys %all ) {
+    $key =~ /^plain_/   and $plain{$key}   = $all{$key};
+    $key =~ /^blessed_/ and $blessed{$key} = $all{$key};
+}
+
+my @all_keys     = sort keys %all;
+my @plain_keys   = sort keys %plain;
+my @blessed_keys = sort keys %blessed;
+
+# FIXME: is_any_ref should added here
+subtest 'is_ref' => sub {
+    # FIXME: is_any_ref() does * 2 on next two lines
+    plan 'tests' => scalar(@all_keys)
+                    + 7;
+
+    foreach my $key (@all_keys) {
+        ok( is_ref( $all{$key} ), "is_ref($key) is true" );
+
+        # FIXME: is_any_ref
+        #ok( is_any_ref( $all{$key} ), "is_any_ref($key) is true" );
+    }
+
+    foreach my $value ( 0, 1, 'string', '', undef, '0', '0e0' ) {
+        # better string representation for test output
+        my $rep = defined $value ? $value eq '' ? q{''} : $value : '(undef)';
+
+        ok( !is_ref($value), "is_ref($rep) is false" );
+
+        # FIXME: is_any_ref
+        #ok( !is_any_ref($value), "is_any_ref($rep) is false" );
+    }
+};
+
+subtest 'plain references' => sub {
+    # I don't have the energy to figure this count
+    #plan 'tests' => scalar(@plain_keys) * scalar(@blessed_keys)
+    #                  # is_blessed_ref() is not in the %blessed hash
+    #                + 1 * scalar(@plain_keys);
+
+    plan 'tests' => 119;
+
+    # each %plain should fail each test of the %blessed
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        ok(
+            !is_blessed_ref($value),
+            "is_blessed_ref($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_scalarref($value),
+            "is_blessed_scalarref($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_arrayref($value),
+            "is_blessed_arrayref($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_hashref($value),
+            "is_blessed_hashref($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_coderef($value),
+            "is_blessed_coderef($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_globref($value),
+            "is_blessed_coderef($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_formatref($value),
+            "is_blessed_formatref($plain_type) is false",
+        );
+
+        ok(
+            !is_blessed_refref($value),
+            "is_blessed_refref($plain_type) is false",
+        );
+    }
+
+    # each should fail everything except their own
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        ok(
+            is_plain_ref($value),
+            "is_plain_ref($plain_type) is true",
+        );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_scalarref'
+            ? ok(
+                is_plain_scalarref($value),
+                "is_plain_scalarref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_scalarref($value),
+                "is_plain_scalarref($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_scalarref'
+            ? ok(
+                is_plain_scalarref($value),
+                "is_plain_scalarref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_scalarref($value),
+                "is_plain_scalarref($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_arrayref'
+            ? ok(
+                is_plain_arrayref($value),
+                "is_plain_arrayref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_arrayref($value),
+                "is_plain_arrayref($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_hashref'
+            ? ok(
+                is_plain_hashref($value),
+                "is_plain_hashref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_hashref($value),
+                "is_plain_hashref($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_coderef'
+            ? ok(
+                is_plain_coderef($value),
+                "is_plain_coderef($plain_type) is true",
+            )
+            : ok(
+                !is_plain_coderef($value),
+                "is_plain_coderef($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_globref'
+            ? ok(
+                is_plain_globref($value),
+                "is_plain_globref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_globref($value),
+                "is_plain_globref($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_formatref'
+            ? ok(
+                is_plain_formatref($value),
+                "is_plain_formatref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_formatref($value),
+                "is_plain_formatref($plain_type) is false",
+            );
+    }
+
+    foreach my $plain_type (@plain_keys) {
+        my $value = $plain{$plain_type};
+
+        $plain_type eq 'plain_globref'
+            ? ok(
+                is_plain_globref($value),
+                "is_plain_globref($plain_type) is true",
+            )
+            : ok(
+                !is_plain_globref($value),
+                "is_plain_globref($plain_type) is false",
+            );
+    }
+};
+
+subtest 'blessed references' => sub {
+    plan 'tests' => 119;
+
+    # each %blessed should fail each test of the %plain
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        ok(
+            !is_plain_ref($value),
+            "is_plain_ref($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_scalarref($value),
+            "is_plain_scalarref($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_arrayref($value),
+            "is_plain_arrayref($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_hashref($value),
+            "is_plain_hashref($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_coderef($value),
+            "is_plain_coderef($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_globref($value),
+            "is_plain_coderef($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_formatref($value),
+            "is_plain_formatref($blessed_type) is false",
+        );
+
+        ok(
+            !is_plain_refref($value),
+            "is_plain_refref($blessed_type) is false",
+        );
+    }
+
+    # each should fail everything except their own
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        ok(
+            is_blessed_ref($value),
+            "is_blessed_ref($blessed_type) is true",
+        );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_scalarref'
+            ? ok(
+                is_blessed_scalarref($value),
+                "is_blessed_scalarref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_scalarref($value),
+                "is_blessed_scalarref($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_scalarref'
+            ? ok(
+                is_blessed_scalarref($value),
+                "is_blessed_scalarref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_scalarref($value),
+                "is_blessed_scalarref($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_arrayref'
+            ? ok(
+                is_blessed_arrayref($value),
+                "is_blessed_arrayref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_arrayref($value),
+                "is_blessed_arrayref($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_hashref'
+            ? ok(
+                is_blessed_hashref($value),
+                "is_blessed_hashref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_hashref($value),
+                "is_blessed_hashref($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_coderef'
+            ? ok(
+                is_blessed_coderef($value),
+                "is_blessed_coderef($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_coderef($value),
+                "is_blessed_coderef($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_globref'
+            ? ok(
+                is_blessed_globref($value),
+                "is_blessed_globref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_globref($value),
+                "is_blessed_globref($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_formatref'
+            ? ok(
+                is_blessed_formatref($value),
+                "is_blessed_formatref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_formatref($value),
+                "is_blessed_formatref($blessed_type) is false",
+            );
+    }
+
+    foreach my $blessed_type (@blessed_keys) {
+        my $value = $blessed{$blessed_type};
+
+        $blessed_type eq 'blessed_globref'
+            ? ok(
+                is_blessed_globref($value),
+                "is_blessed_globref($blessed_type) is true",
+            )
+            : ok(
+                !is_blessed_globref($value),
+                "is_blessed_globref($blessed_type) is false",
+            );
+    }
+};

--- a/t/all-permutations.t
+++ b/t/all-permutations.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More 'tests' => 3;
+use Test::More 'tests' => 5;
 use Ref::Util ':all';
 
 # FIXME: plain regular expressions, blessed regular expressions
@@ -72,13 +72,8 @@ subtest 'non-refs' => sub {
     }
 };
 
-subtest 'plain references' => sub {
-    # I don't have the energy to figure this count
-    #plan 'tests' => scalar(@plain_keys) * scalar(@blessed_keys)
-    #                  # is_blessed_ref() is not in the %blessed hash
-    #                + 1 * scalar(@plain_keys);
-
-    plan 'tests' => 168;
+subtest 'plain references only work on is_plain functions' => sub {
+    plan 'tests' => 56;
 
     # each %plain should fail each test of the %blessed
     foreach my $plain_type (@plain_keys) {
@@ -124,6 +119,10 @@ subtest 'plain references' => sub {
             "is_blessed_refref($plain_type) is false",
         );
     }
+};
+
+subtest 'plain references' => sub {
+    plan 'tests' => 112;
 
     # each should fail everything except their own
     foreach my $plain_type (@plain_keys) {
@@ -329,8 +328,8 @@ subtest 'plain references' => sub {
     }
 };
 
-subtest 'blessed references' => sub {
-    plan 'tests' => 168;
+subtest 'blessed references only work on is_blessed functions' => sub {
+    plan 'tests' => 56;
 
     # each %blessed should fail each test of the %plain
     foreach my $blessed_type (@blessed_keys) {
@@ -376,6 +375,10 @@ subtest 'blessed references' => sub {
             "is_plain_refref($blessed_type) is false",
         );
     }
+};
+
+subtest 'blessed references' => sub {
+    plan 'tests' => 112;
 
     # each should fail everything except their own
     foreach my $blessed_type (@blessed_keys) {


### PR DESCRIPTION
Wow. This took a while. Mostly to figure out, then write it out
cleanly. Plenty of copy pasting and search/replace with Vim.

Why? Because I didn't want to do it dynamically.

This tests several things:
- Various common non-ref values do not pass is_ref().
- All plain references must pass is_plain_ref().
- All plain references fail all of the is_blessed_\* functions.
- Each plain reference only passes a test for its type.
- All blessed references must pass is_blessed_ref().
- All blessed references fail all of the is_plain_\* functions.
- Each blessed reference only passes a test for its type.
- All references (plain or blessed) should pass the is_ref().

Things still to do:
- Only test the formatref is it's > 5.6. Gotta add that distinction.
- Get plan count to be based on the hashes - not that important.
- Once is_any_\* variant comes in (now's the time), it should be
  added to the tests.
